### PR TITLE
extra comma

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": "~5.6.0|~7.0.0",
         "tcesarpinho/php-sigep": ">=0.0.1",
         "cagartner/phpquery": ">=0.9.8",
-        "ext-soap": "*",
+        "ext-soap": "*"
     },
     "autoload": {
         "files": [


### PR DESCRIPTION
```
[Seld\JsonLint\ParsingException]                                  
  "./composer.json" does not contain valid JSON                     
  Parse error on line 10:                                           
  ...ext-soap": "*",    },    "autoload": {                         
  ---------------------^                                            
  Expected: 'STRING' - It appears you have an extra trailing comma
```

Acredito que esse seja o motivo do pacote não ter sido atualizado para a versão 0.0.2 no packagist.
closes #2 